### PR TITLE
Hotfix for LaTeX Workbench on Windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,21 @@
 {
   "latex-workshop.latex.tools": [
     {
-      "name": "tectonic",
-      "command": "bash",
+      "name": "pygmentise",
+      "command": "node",
       "args": [
+        "../bin/latex_workshop_hotfix",
         "-i",
-        "../bin/report"
+        "../bin/pyg"
+      ]
+    },
+    {
+      "name": "tectonic",
+      "command": "node",
+      "args": [
+        "../bin/latex_workshop_hotfix",
+        "-i",
+        "../bin/tex"
       ]
     }
   ],
@@ -13,6 +23,7 @@
     {
       "name": "Build LaTeX",
       "tools": [
+        "pygmentise",
         "tectonic"
       ]
     }

--- a/bin/latex_workshop_hotfix
+++ b/bin/latex_workshop_hotfix
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+let{spawn}=require('child_process'),c=spawn('bash',process.argv.slice(2))
+c.stdout.pipe(process.stdout)
+c.stderr.pipe(process.stderr)
+c.stdin.end()


### PR DESCRIPTION
Bash never *exits* when spawned by Node, so has to be ended manually. LW currently doesn't do this so need to nest another spawn inside its spawned process.